### PR TITLE
Update The Asynchronous Action Creator To An Appropriate Type

### DIFF
--- a/rrts/src/actions/todos.ts
+++ b/rrts/src/actions/todos.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import { Dispatch } from 'redux';
+import { ThunkAction } from 'redux-thunk';
 import { ActionTypes } from './types';
+import { StoreState } from '../reducers';
 
 export interface Todo {
   id: number;
@@ -20,11 +22,11 @@ export interface DeleteTodoAction {
 
 const url = 'https://jsonplaceholder.typicode.com/todos';
 
-export const fetchTodos = () => {
-  return async (dispatch: Dispatch) => {
+export const fetchTodos = (): ThunkAction<Promise<void>, StoreState, null, FetchTodosAction> => {
+  return async (dispatch: Dispatch<FetchTodosAction>): Promise<void> => {
     const response = await axios.get<Todo[]>(url);
 
-    dispatch<FetchTodosAction>({
+    dispatch({
       type: ActionTypes.fetchTodos,
       payload: response.data
     });

--- a/rrts/src/components/App.tsx
+++ b/rrts/src/components/App.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Todo, fetchTodos, deleteTodo } from '../actions';
+import { ThunkDispatch } from 'redux-thunk';
+import { Todo, Action, fetchTodos, deleteTodo } from '../actions';
 import { StoreState } from '../reducers';
 
 interface AppProps {
   todos: Todo[];
-  fetchTodos: Function;
-  deleteTodo: typeof deleteTodo;
+  fetchTodos(): void;
+  deleteTodo(id: number): void;
 }
 
 interface AppState {
@@ -60,7 +61,19 @@ const mapStateToProps = ({ todos }: StoreState): { todos: Todo[] } => {
   return { todos };
 };
 
+const mapDispatchToProps = (dispatch: ThunkDispatch<StoreState, null, Action>): {
+  fetchTodos(): void;
+  deleteTodo(id: number): void;
+} => ({
+  fetchTodos(): void {
+    dispatch(fetchTodos());
+  },
+  deleteTodo(id: number): void {
+    dispatch(deleteTodo(id));
+  }
+});
+
 export const App = connect(
   mapStateToProps,
-  { fetchTodos, deleteTodo }
+  mapDispatchToProps
 )(_App);


### PR DESCRIPTION
Below are the updates in this pull request:

1. Updated the type of the second argument of `connect` function from `TDispatchProps` to `MapDispatchToPropsFunction<TDispatchProps, TOwnProps>`, having `connect` identify both asynchronous thunk action and action object correctly
2. Annotated the return value of `fetchTodos` action creator to the type of `ThunkAction<R, S, E, A extends Action>`
3. Annotated the return value of thunk action of `fetchTodos` to the type of `Promise<void>`

Feel free to let me know what you think, @StephenGrider Thank you!