### PR TITLE
Fix team refrence in win-analyzer file in stats projects

### DIFF
--- a/stats/src/analyzers/WinsAnalysis.ts
+++ b/stats/src/analyzers/WinsAnalysis.ts
@@ -9,12 +9,9 @@ export class WinsAnalysis implements Analyzer {
     let wins = 0;
 
     for (let match of matches) {
-      if (match[1] === 'Man United' && match[5] === MatchResult.HomeWin) {
+      if (match[1] === this.team && match[5] === MatchResult.HomeWin) {
         wins++;
-      } else if (
-        match[2] === 'Man United' &&
-        match[5] === MatchResult.AwayWin
-      ) {
+      } else if (match[2] === this.team && match[5] === MatchResult.AwayWin) {
         wins++;
       }
     }


### PR DESCRIPTION
Mr Stephen, You forget to replace 'Man United' with this.team on refactoring this to separate file.